### PR TITLE
Improve eth trading backtesting algorithm

### DIFF
--- a/backtest.py
+++ b/backtest.py
@@ -118,14 +118,22 @@ def load_strategy(strategy_name: str):
         print(f"❌ Error loading strategy '{strategy_name}': {e}")
         return None
 
-def run_strategy_backtest(df: pd.DataFrame, strategy_class, investment_amount: float = 1000):
-    """Run backtest with CPU-friendly pauses."""
-    print(f"🎯 Running {strategy_class.__name__} backtest...")
-    print(f"💰 Initial investment: ${investment_amount:,.2f}")
-    print(f"📊 Processing {len(df):,} data points with 0.3s pauses between days...")
-    
+def run_strategy_backtest(df: pd.DataFrame, strategy_or_class, investment_amount: float = 1000, silent: bool = False, strategy_kwargs: Dict[str, Any] | None = None):
+    """Run backtest with CPU-friendly pauses.
+    strategy_or_class can be a class or a pre-instantiated strategy.
+    """
     # Initialize strategy
-    strategy = strategy_class(initial_balance=investment_amount)
+    if isinstance(strategy_or_class, type):
+        strategy = strategy_or_class(initial_balance=investment_amount, **(strategy_kwargs or {}))
+        strategy_name = strategy_or_class.__name__
+    else:
+        strategy = strategy_or_class
+        strategy_name = strategy.__class__.__name__
+    
+    if not silent:
+        print(f"🎯 Running {strategy_name} backtest...")
+        print(f"💰 Initial investment: ${investment_amount:,.2f}")
+        print(f"📊 Processing {len(df):,} data points with 0.3s pauses between days...")
     
     # Group data by day to add pauses
     df['date'] = pd.to_datetime(df['timestamp'], unit='s').dt.date
@@ -145,7 +153,8 @@ def run_strategy_backtest(df: pd.DataFrame, strategy_class, investment_amount: f
     else:
         total_days = daily_groups.ngroups
     
-    print(f"📅 Processing {total_days:,} days of data...")
+    if not silent:
+        print(f"📅 Processing {total_days:,} days of data...")
     
     start_time = time.time()
     processed_days = 0
@@ -193,7 +202,8 @@ def run_strategy_backtest(df: pd.DataFrame, strategy_class, investment_amount: f
         pnl_color = "🟢" if daily_pnl >= 0 else "🔴"
         total_color = "🟢" if total_pnl >= 0 else "🔴"
         
-        print(f"📅 {date} | 💰 ${current_value:,.0f} | {pnl_color} Day: {daily_pnl:+.0f} | {total_color} Total: {total_pnl:+.1f}% | 📊 ETH: ${final_price_of_day:.0f} | 🔄 {strategy.portfolio.trades_count} trades")
+        if not silent:
+            print(f"📅 {date} | 💰 ${current_value:,.0f} | {pnl_color} Day: {daily_pnl:+.0f} | {total_color} Total: {total_pnl:+.1f}% | 📊 ETH: ${final_price_of_day:.0f} | 🔄 {strategy.portfolio.trades_count} trades")
         
         # Record end-of-day portfolio state for next day's comparison
         strategy.portfolio_history.append({
@@ -205,7 +215,7 @@ def run_strategy_backtest(df: pd.DataFrame, strategy_class, investment_amount: f
         })
         
         # Progress milestone every 100 days
-        if processed_days % 100 == 0:
+        if not silent and processed_days % 100 == 0:
             progress = (processed_days / total_days) * 100
             elapsed = time.time() - start_time
             estimated_total = (elapsed / processed_days) * total_days
@@ -217,7 +227,8 @@ def run_strategy_backtest(df: pd.DataFrame, strategy_class, investment_amount: f
         if sleep_sec > 0:
             time.sleep(sleep_sec)
     
-    print(f"✅ Backtest completed in {(time.time() - start_time)/60:.1f} minutes")
+    if not silent:
+        print(f"✅ Backtest completed in {(time.time() - start_time)/60:.1f} minutes")
     
     # Calculate final results
     final_value = strategy.portfolio.total_value
@@ -234,7 +245,7 @@ def run_strategy_backtest(df: pd.DataFrame, strategy_class, investment_amount: f
         max_drawdown = 0
     
     return {
-        'strategy_name': strategy_class.__name__,
+        'strategy_name': strategy_name,
         'initial_investment': investment_amount,
         'final_value': final_value,
         'total_return': total_return,
@@ -349,9 +360,26 @@ def main():
         list_available_strategies()
         sys.exit(1)
     
+    # Parse optional strategy kwargs like key=value after amount
+    strategy_kwargs: Dict[str, Any] = {}
+    if len(sys.argv) > 3:
+        for arg in sys.argv[3:]:
+            if '=' in arg:
+                key, value = arg.split('=', 1)
+                key = key.strip()
+                value = value.strip()
+                if value.lower() in {'true', 'false'}:
+                    cast_value = value.lower() == 'true'
+                else:
+                    try:
+                        cast_value = float(value) if '.' in value else int(value)
+                    except Exception:
+                        cast_value = value
+                strategy_kwargs[key] = cast_value
+    
     # Run strategy backtest
     print(f"\n🎮 Running strategy backtest...")
-    strategy_results = run_strategy_backtest(df, strategy_class, investment_amount)
+    strategy_results = run_strategy_backtest(df, strategy_class, investment_amount, silent=False, strategy_kwargs=strategy_kwargs)
     
     # Display results
     display_results(hodl_results, strategy_results)

--- a/backtest.py
+++ b/backtest.py
@@ -130,7 +130,20 @@ def run_strategy_backtest(df: pd.DataFrame, strategy_class, investment_amount: f
     # Group data by day to add pauses
     df['date'] = pd.to_datetime(df['timestamp'], unit='s').dt.date
     daily_groups = df.groupby('date')
-    total_days = len(daily_groups)
+    # Optional limit for quick test runs
+    max_days_env = os.getenv('BACKTEST_MAX_DAYS')
+    if max_days_env is not None:
+        try:
+            max_days = int(max_days_env)
+            unique_dates = list(daily_groups.groups.keys())[:max_days]
+            daily_groups = ((d, df[df['date'] == d]) for d in unique_dates)
+            total_days = len(unique_dates)
+        except Exception:
+            # Fallback to full dataset if env var invalid
+            daily_groups = df.groupby('date')
+            total_days = daily_groups.ngroups
+    else:
+        total_days = daily_groups.ngroups
     
     print(f"📅 Processing {total_days:,} days of data...")
     
@@ -199,8 +212,10 @@ def run_strategy_backtest(df: pd.DataFrame, strategy_class, investment_amount: f
             remaining = estimated_total - elapsed
             print(f"   🎯 MILESTONE: {progress:.1f}% complete ({processed_days}/{total_days} days) | ⏱️ ETA: {remaining/60:.1f}m | 💎 Portfolio: ${current_value:,.0f}")
         
-        # CPU-friendly pause between days
-        time.sleep(0.15)
+        # CPU-friendly pause between days (configurable)
+        sleep_sec = float(os.getenv('BACKTEST_SLEEP_SEC', '0.15'))
+        if sleep_sec > 0:
+            time.sleep(sleep_sec)
     
     print(f"✅ Backtest completed in {(time.time() - start_time)/60:.1f} minutes")
     

--- a/strategies/buy_and_hold.py
+++ b/strategies/buy_and_hold.py
@@ -1,0 +1,36 @@
+#!/usr/bin/env python3
+"""
+Buy and Hold Strategy (for baseline comparison within the same framework)
+
+Executes one initial buy with nearly full allocation and then holds.
+
+Run via: python backtest.py buy_and_hold
+Class name: BuyAndHoldStrategy
+"""
+
+from typing import Dict, Tuple
+
+from strategies.simple_grid import TradingStrategy
+
+
+class BuyAndHoldStrategy(TradingStrategy):
+    def __init__(self, initial_balance: float = 1000.0, fee_rate: float = 0.001):
+        super().__init__(initial_balance=initial_balance, fee_rate=fee_rate)
+        self._initialized = False
+
+    def should_buy(self, current_price: float, data: Dict) -> Tuple[bool, str]:
+        if not self._initialized and self.portfolio.cash > 0:
+            return True, "Initial full allocation"
+        return False, "Already allocated"
+
+    def should_sell(self, current_price: float, data: Dict) -> Tuple[bool, str]:
+        return False, "Never sell"
+
+    def get_trade_amount(self, current_price: float, action: str) -> float:
+        if action == 'BUY' and not self._initialized:
+            # Keep small buffer for fees
+            amount = max(0.0, self.portfolio.cash - 1.0)
+            self._initialized = True
+            return amount
+        return 0.0
+

--- a/strategies/donchian_breakout.py
+++ b/strategies/donchian_breakout.py
@@ -1,0 +1,152 @@
+#!/usr/bin/env python3
+"""
+Donchian Breakout Strategy (Long-only, 5m)
+
+Rules:
+- 200 EMA filter: only take longs when close > EMA200
+- Entry: breakout above N-high (e.g., 55)
+- Exit: close below M-low (e.g., 20) or below EMA200
+- Position sizing: target up to 100% in regime, rebalance on drift
+
+Run via: python backtest.py donchian_breakout
+Class name: DonchianBreakoutStrategy
+"""
+
+from typing import Dict, Tuple, Deque
+from collections import deque
+
+from strategies.simple_grid import TradingStrategy
+
+
+class DonchianBreakoutStrategy(TradingStrategy):
+    def __init__(
+        self,
+        initial_balance: float = 1000.0,
+        fee_rate: float = 0.001,
+        breakout_lookback: int = 55,
+        exit_lookback: int = 20,
+        ema_period: int = 200,
+        rebalance_threshold: float = 0.02,
+        max_trade_fraction: float = 0.3,
+        target_allocation: float = 0.98,
+    ):
+        self.breakout_lookback = breakout_lookback
+        self.exit_lookback = exit_lookback
+        self.ema_period = ema_period
+        self.rebalance_threshold = rebalance_threshold
+        self.max_trade_fraction = max_trade_fraction
+        self._ema = None
+
+        self._high_window: Deque[float] = deque(maxlen=breakout_lookback)
+        self._low_window: Deque[float] = deque(maxlen=exit_lookback)
+        self._last_ts = None  # not used now
+        self._target_allocation = target_allocation
+
+        super().__init__(initial_balance=initial_balance, fee_rate=fee_rate)
+
+    def _ema_update(self, prev: float, price: float, period: int) -> float:
+        k = 2 / (period + 1)
+        if prev is None:
+            return price
+        return price * k + prev * (1 - k)
+
+    def _update(self, data: Dict):
+        c = data['close']
+        h = data['high']
+        l = data['low']
+        self._ema = self._ema_update(self._ema, c, self.ema_period)
+        self._high_window.append(h)
+        self._low_window.append(l)
+        # process each tick; no timestamp dependency
+
+    def _in_regime(self, price: float) -> bool:
+        if self._ema is None:
+            return False
+        return price > self._ema
+
+    def _current_allocation(self, price: float) -> float:
+        total_value = self.portfolio.cash + self.portfolio.eth * price
+        if total_value <= 0:
+            return 0.0
+        return (self.portfolio.eth * price) / total_value
+
+    def _needs_rebalance(self, price: float, target_alloc: float) -> Tuple[bool, float]:
+        current = self._current_allocation(price)
+        drift = target_alloc - current
+        return (abs(drift) >= self.rebalance_threshold, drift)
+
+    def should_buy(self, current_price: float, data: Dict) -> Tuple[bool, str]:
+        self._update(data=data)
+        if not self._in_regime(current_price):
+            return False, "Below EMA filter"
+        if len(self._high_window) < self._high_window.maxlen:
+            return False, "Insufficient history"
+        breakout_level = max(self._high_window)
+        if current_price > breakout_level:
+            need, drift = self._needs_rebalance(current_price, self._target_allocation)
+            if need and drift > 0:
+                return True, f"Breakout above {breakout_level:.2f} and drift {drift:+.2%}"
+        return False, "No buy"
+
+    def should_sell(self, current_price: float, data: Dict) -> Tuple[bool, str]:
+        self._update(data=data)
+        # Exit if below EMA or below M-low
+        exit_trigger = False
+        reason = "Hold"
+        if self._ema is not None and current_price < self._ema:
+            exit_trigger = True
+            reason = "Exit: below EMA"
+        if len(self._low_window) == self._low_window.maxlen:
+            exit_level = min(self._low_window)
+            if current_price < exit_level:
+                exit_trigger = True
+                reason = f"Exit: below {self.exit_lookback}-low {exit_level:.2f}"
+
+        if exit_trigger:
+            return True, reason
+
+        # Rebalance down if drifted above target
+        need, drift = self._needs_rebalance(current_price, self._target_allocation)
+        if need and drift < 0:
+            return True, f"Rebalance down (drift {drift:+.2%})"
+        return False, "Hold"
+
+    def get_trade_amount(self, current_price: float, action: str) -> float:
+        total_value = self.portfolio.cash + self.portfolio.eth * current_price
+        target_value = self._target_allocation * total_value
+        current_value = self.portfolio.eth * current_price
+        delta_value = target_value - current_value
+
+        if action == 'BUY' and delta_value > 0:
+            desired = min(delta_value, self.portfolio.cash)
+            desired = min(desired, self.max_trade_fraction * self.portfolio.cash)
+            return max(0.0, desired)
+
+        if action == 'SELL' and delta_value < 0:
+            desired = min(-delta_value, self.portfolio.eth * current_price)
+            desired = min(desired, self.max_trade_fraction * self.portfolio.eth * current_price)
+            return max(0.0, desired / current_price if current_price > 0 else 0.0)
+
+        return 0.0
+
+    def process_tick(self, timestamp: int, datetime_str: str, price_data: Dict):
+        # Override base to avoid initial forced 50% buy
+        current_price = price_data['close']
+
+        # Update indicators first
+        self._update(price_data)
+
+        should_buy, buy_reason = self.should_buy(current_price, price_data)
+        should_sell, sell_reason = self.should_sell(current_price, price_data)
+
+        if should_buy and not should_sell:
+            amount = self.get_trade_amount(current_price, 'BUY')
+            if amount > 0:
+                self.execute_trade(timestamp, datetime_str, current_price, 'BUY', amount, buy_reason)
+        elif should_sell and not should_buy:
+            amount = self.get_trade_amount(current_price, 'SELL')
+            if amount > 0:
+                self.execute_trade(timestamp, datetime_str, current_price, 'SELL', amount, sell_reason)
+
+        self.update_portfolio_value(current_price)
+

--- a/strategies/ema_atr_trend.py
+++ b/strategies/ema_atr_trend.py
@@ -1,0 +1,217 @@
+#!/usr/bin/env python3
+"""
+EMA + ATR Trend-Following Strategy (Long-only)
+
+Core ideas for 5m ETH:
+- Trade only long and bias exposure by regime
+- Regime = EMA(short) above EMA(long)
+- Target high allocation in uptrends; cut to minimal in downtrends
+- Use ATR-based trailing stop and EMA(long)-ATR safety exit
+- Rebalance only when allocation drift exceeds threshold to reduce churn
+
+Run via: python backtest.py ema_atr_trend
+Class name: EmaAtrTrendStrategy
+"""
+
+from typing import Dict, Tuple
+from dataclasses import dataclass
+
+# Reuse base components from simple_grid
+from strategies.simple_grid import TradingStrategy
+
+
+class EmaAtrTrendStrategy(TradingStrategy):
+    def __init__(
+        self,
+        initial_balance: float = 1000.0,
+        fee_rate: float = 0.001,
+        short_ema_period: int = 50,
+        long_ema_period: int = 200,
+        atr_period: int = 14,
+        risk_atr_multiple: float = 3.0,
+        max_allocation: float = 0.95,
+        min_allocation: float = 0.05,
+        rebalance_threshold: float = 0.02,  # 2% allocation drift
+        max_trade_fraction: float = 0.25,   # cap per trade to 25% of available
+    ):
+        self.short_ema_period = short_ema_period
+        self.long_ema_period = long_ema_period
+        self.atr_period = atr_period
+        self.risk_atr_multiple = risk_atr_multiple
+        self.max_allocation = max_allocation
+        self.min_allocation = min_allocation
+        self.rebalance_threshold = rebalance_threshold
+        self.max_trade_fraction = max_trade_fraction
+
+        # Indicator state
+        self._bar_count = 0
+        self._ema_short = None
+        self._ema_long = None
+        self._prev_close = None
+        self._atr = None
+        self._tr_sma_accumulator = 0.0
+        self._highest_close_in_trend = None
+        self._in_uptrend = False
+        self._last_updated_close_ts = None  # no-op now; kept for clarity
+
+        super().__init__(initial_balance=initial_balance, fee_rate=fee_rate)
+
+    # ---- Indicator helpers ----
+    def _wilder_smooth(self, prev_value: float, new_value: float, period: int) -> float:
+        if prev_value is None:
+            return new_value
+        return (prev_value * (period - 1) + new_value) / period
+
+    def _ema_update(self, prev_ema: float, price: float, period: int) -> float:
+        k = 2 / (period + 1)
+        if prev_ema is None:
+            return price
+        return price * k + prev_ema * (1 - k)
+
+    def _update_indicators(self, data: Dict):
+        close_price = data['close']
+        high_price = data['high']
+        low_price = data['low']
+
+        # Update EMAs
+        self._ema_short = self._ema_update(self._ema_short, close_price, self.short_ema_period)
+        self._ema_long = self._ema_update(self._ema_long, close_price, self.long_ema_period)
+
+        # Update ATR (Wilder)
+        if self._prev_close is None:
+            tr = high_price - low_price
+        else:
+            tr = max(
+                high_price - low_price,
+                abs(high_price - self._prev_close),
+                abs(low_price - self._prev_close),
+            )
+
+        if self._bar_count < self.atr_period:
+            # Build initial SMA of TR
+            self._tr_sma_accumulator += tr
+            if self._bar_count + 1 == self.atr_period:
+                self._atr = self._tr_sma_accumulator / self.atr_period
+        else:
+            self._atr = self._wilder_smooth(self._atr, tr, self.atr_period)
+
+        # Track regime and trailing reference
+        if self._ema_short is not None and self._ema_long is not None:
+            uptrend_now = self._ema_short > self._ema_long
+            if uptrend_now:
+                if self._in_uptrend:
+                    # continue tracking highest close during uptrend
+                    if self._highest_close_in_trend is None:
+                        self._highest_close_in_trend = close_price
+                    else:
+                        self._highest_close_in_trend = max(self._highest_close_in_trend, close_price)
+                else:
+                    # entering uptrend
+                    self._highest_close_in_trend = close_price
+            else:
+                # reset when exiting uptrend
+                self._highest_close_in_trend = None
+            self._in_uptrend = uptrend_now
+
+        self._prev_close = close_price
+        self._bar_count += 1
+        # No timestamp dependency; update every tick
+
+    # ---- Signal logic ----
+    def _target_allocation(self) -> float:
+        # Prefer high exposure in uptrends, minimal otherwise
+        if self._in_uptrend:
+            return self.max_allocation
+        return self.min_allocation
+
+    def _current_allocation(self, price: float) -> float:
+        total_value = self.portfolio.cash + self.portfolio.eth * price
+        if total_value <= 0:
+            return 0.0
+        return (self.portfolio.eth * price) / total_value
+
+    def _needs_rebalance(self, price: float) -> Tuple[bool, float]:
+        target = self._target_allocation()
+        current = self._current_allocation(price)
+        drift = target - current
+        return (abs(drift) >= self.rebalance_threshold, drift)
+
+    def _atr_stop_triggered(self, price: float) -> bool:
+        if self._atr is None or self._ema_long is None:
+            return False
+        safety_level = self._ema_long - self._atr  # buffer below long EMA
+        if self._highest_close_in_trend is not None:
+            trailing_level = self._highest_close_in_trend - self.risk_atr_multiple * self._atr
+        else:
+            trailing_level = None
+
+        trigger = False
+        if trailing_level is not None and price < trailing_level:
+            trigger = True
+        if price < safety_level:
+            trigger = True
+        return trigger
+
+    def should_buy(self, current_price: float, data: Dict) -> Tuple[bool, str]:
+        self._update_indicators(data=data)
+        # Emergency de-risk handled in should_sell; buy targets towards regime allocation
+        need, drift = self._needs_rebalance(current_price)
+        if need and drift > 0:
+            return True, f"Rebalance up towards {self._target_allocation():.0%} (drift {drift:+.2%})"
+        return False, "No buy"
+
+    def should_sell(self, current_price: float, data: Dict) -> Tuple[bool, str]:
+        self._update_indicators(data=data)
+        # Forced de-risk on ATR stop or regime shift down
+        if self._atr_stop_triggered(current_price):
+            return True, "ATR/EMA safety exit"
+        need, drift = self._needs_rebalance(current_price)
+        if need and drift < 0:
+            return True, f"Rebalance down towards {self._target_allocation():.0%} (drift {drift:+.2%})"
+        return False, "Hold"
+
+    def get_trade_amount(self, current_price: float, action: str) -> float:
+        # Translate target allocation into concrete trade size
+        total_value = self.portfolio.cash + self.portfolio.eth * current_price
+        target_value_in_eth = self._target_allocation() * total_value
+        current_value_in_eth = self.portfolio.eth * current_price
+        delta_value = target_value_in_eth - current_value_in_eth
+
+        if action == 'BUY' and delta_value > 0:
+            # Cap by available cash and per-trade fraction
+            desired_cash = min(delta_value, self.portfolio.cash)
+            desired_cash = min(desired_cash, self.max_trade_fraction * self.portfolio.cash)
+            return max(0.0, desired_cash)
+
+        if action == 'SELL' and delta_value < 0:
+            # Convert desired value reduction into ETH amount
+            desired_reduction_value = min(-delta_value, self.portfolio.eth * current_price)
+            desired_reduction_value = min(desired_reduction_value, self.max_trade_fraction * self.portfolio.eth * current_price)
+            eth_to_sell = desired_reduction_value / current_price if current_price > 0 else 0.0
+            return max(0.0, eth_to_sell)
+
+        return 0.0
+
+    def process_tick(self, timestamp: int, datetime_str: str, price_data: Dict):
+        # Override base to avoid initial forced 50% buy
+        current_price = price_data['close']
+
+        # Update indicators first
+        self._update_indicators(price_data)
+
+        # Evaluate signals
+        should_buy, buy_reason = self.should_buy(current_price, price_data)
+        should_sell, sell_reason = self.should_sell(current_price, price_data)
+
+        if should_buy and not should_sell:
+            amount = self.get_trade_amount(current_price, 'BUY')
+            if amount > 0:
+                self.execute_trade(timestamp, datetime_str, current_price, 'BUY', amount, buy_reason)
+        elif should_sell and not should_buy:
+            amount = self.get_trade_amount(current_price, 'SELL')
+            if amount > 0:
+                self.execute_trade(timestamp, datetime_str, current_price, 'SELL', amount, sell_reason)
+
+        # Update portfolio value
+        self.update_portfolio_value(current_price)
+

--- a/sweep_strategies.py
+++ b/sweep_strategies.py
@@ -1,0 +1,143 @@
+#!/usr/bin/env python3
+"""
+Parameter sweep runner (Windows-friendly)
+
+Runs multiple strategies with different parameter grids using the in-process
+backtester (silent mode). Summarizes and prints the best configuration.
+
+Usage examples:
+  python sweep_strategies.py --max-days 180 --sleep-sec 0 --amount 1000
+
+On Windows PowerShell you can also set env vars:
+  $env:BACKTEST_MAX_DAYS=180; $env:BACKTEST_SLEEP_SEC=0; python sweep_strategies.py
+"""
+
+import os
+import argparse
+import importlib
+from typing import Dict, Any, List, Tuple
+
+import pandas as pd
+
+from backtest import load_all_eth_data, calculate_hodl_performance, run_strategy_backtest
+
+
+def run_one(
+    df: pd.DataFrame,
+    strategy_path: str,
+    cls_name: str,
+    amount: float,
+    kwargs: Dict[str, Any],
+) -> Dict[str, Any]:
+    module = importlib.import_module(strategy_path)
+    strategy_cls = getattr(module, cls_name)
+    return run_strategy_backtest(
+        df=df,
+        strategy_or_class=strategy_cls,
+        investment_amount=amount,
+        silent=True,
+        strategy_kwargs=kwargs,
+    )
+
+
+def grid(params: Dict[str, List[Any]]) -> List[Dict[str, Any]]:
+    from itertools import product
+    keys = list(params.keys())
+    values = [params[k] for k in keys]
+    combos = []
+    for items in product(*values):
+        combos.append({k: v for k, v in zip(keys, items)})
+    return combos
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--amount', type=float, default=1000.0)
+    parser.add_argument('--max-days', type=int, default=None)
+    parser.add_argument('--sleep-sec', type=float, default=None)
+    args = parser.parse_args()
+
+    if args.max_days is not None:
+        os.environ['BACKTEST_MAX_DAYS'] = str(args.max_days)
+    if args.sleep_sec is not None:
+        os.environ['BACKTEST_SLEEP_SEC'] = str(args.sleep_sec)
+
+    df = load_all_eth_data()
+    if df is None:
+        raise SystemExit(1)
+    hodl = calculate_hodl_performance(df, args.amount)
+
+    experiments: List[Tuple[str, str, Dict[str, Any]]] = []
+
+    # EMA+ATR Trend sweeps
+    ema_atr_grid = grid({
+        'short_ema_period': [34, 50, 72],
+        'long_ema_period': [144, 200, 288],
+        'atr_period': [14, 21],
+        'risk_atr_multiple': [2.5, 3.0, 3.5],
+        'max_allocation': [0.9, 0.95, 0.99],
+        'min_allocation': [0.0, 0.05],
+        'rebalance_threshold': [0.01, 0.02, 0.05],
+        'max_trade_fraction': [0.2, 0.3],
+    })
+    for kw in ema_atr_grid:
+        experiments.append(('strategies.ema_atr_trend', 'EmaAtrTrendStrategy', kw))
+
+    # Donchian sweeps
+    donchian_grid = grid({
+        'breakout_lookback': [40, 55, 80],
+        'exit_lookback': [10, 20, 30],
+        'ema_period': [150, 200, 250],
+        'target_allocation': [0.9, 0.98, 1.0],
+        'rebalance_threshold': [0.01, 0.02, 0.05],
+        'max_trade_fraction': [0.2, 0.3],
+    })
+    for kw in donchian_grid:
+        experiments.append(('strategies.donchian_breakout', 'DonchianBreakoutStrategy', kw))
+
+    # Simple grid sanity sweep (optional)
+    simple_grid_grid = grid({
+        'price_threshold': [0.005, 0.01, 0.02],
+        'trade_size_percent': [0.05, 0.1, 0.15],
+    })
+    for kw in simple_grid_grid:
+        experiments.append(('strategies.simple_grid', 'SimpleGridStrategy', kw))
+
+    results = []
+    for mod, cls, kw in experiments:
+        try:
+            res = run_one(df, mod, cls, args.amount, kw)
+            results.append((mod, cls, kw, res))
+        except Exception as e:
+            print(f"❌ Failed {mod}.{cls} {kw}: {e}")
+
+    # Rank by final value
+    results.sort(key=lambda x: x[3]['final_value'], reverse=True)
+    best = results[0] if results else None
+
+    print("\n=== SWEEP SUMMARY ===")
+    print(f"HODL final: ${hodl['final_value']:,.2f} | Return: {hodl['percent_return']:.2f}%")
+    if best:
+        mod, cls, kw, res = best
+        print(f"BEST: {mod}.{cls} {kw}")
+        print(f"Final: ${res['final_value']:,.2f} | Return: {res['total_return']:.2f}% | MDD: {res['max_drawdown']:.2f}% | Trades: {res['total_trades']}")
+    else:
+        print("No successful runs.")
+
+    # Print top 5
+    print("\nTop 5:")
+    for i, (mod, cls, kw, res) in enumerate(results[:5], 1):
+        print(f"{i}. {mod}.{cls} {kw} => ${res['final_value']:,.0f} | {res['total_return']:.1f}% | MDD {res['max_drawdown']:.1f}% | trades {res['total_trades']}")
+
+    # Suggested command to run best on full data (Windows example)
+    if best:
+        mod, cls, kw, res = best
+        strat_name = mod.split('.')[-1]
+        args_kv = ' '.join([f"{k}={v}" for k, v in kw.items()])
+        print("\nRun best on full data (Windows PowerShell):")
+        print(f".\\.venv\\Scripts\\python.exe .\\backtest.py {strat_name} {args.amount} {args_kv}")
+
+
+if __name__ == "__main__":
+    main()
+


### PR DESCRIPTION
Add three new trading strategies (Buy and Hold, EMA+ATR Trend, Donchian Breakout) and enhance the backtester for faster iteration.

The existing `simple_grid` strategy significantly underperformed a buy-and-hold approach. These new strategies introduce more sophisticated trend-following and breakout logic with risk management, aiming for superior returns. The backtester enhancements allow for quicker validation and tuning of these strategies.

---
<a href="https://cursor.com/background-agent?bcId=bc-0105820d-9eee-4abf-ae1a-d68fc58795c6">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-0105820d-9eee-4abf-ae1a-d68fc58795c6">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

